### PR TITLE
Responder json helper method custom status support

### DIFF
--- a/backend/src/Utils/Responder.php
+++ b/backend/src/Utils/Responder.php
@@ -12,9 +12,9 @@ final class Responder {
         return Responder::json($res, ["ok" => false, "error" => "Unimplemented"]);
     }
 
-    public static function json(Response $res, array $data): Response {
+    public static function json(Response $res, array $data, int $status = 200): Response {
         $res->getBody()->write(json_encode($data, JSON_UNESCAPED_SLASHES));
-        return $res->withHeader('Content-Type', 'application/json')->withStatus(200);
+        return $res->withHeader('Content-Type', 'application/json')->withStatus($status);
     }
 
     public static function getBody(Request $req): null | array | object {


### PR DESCRIPTION
Added status parameter to the json helper method on the Responder util so that we can properly handle API errors and alternative API success codes.

Made the parameter optional so that existing code without it won't break and will just default to 200 like it already was.